### PR TITLE
openPMD-api: 0.12.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 h5py
 matplotlib
 numpy
-openpmd_api
+openpmd-api>=0.12.0,<0.13.0
 scipy>=1.0.0
 

--- a/scripts/wpg_to_opmd.py
+++ b/scripts/wpg_to_opmd.py
@@ -105,7 +105,7 @@ def convertToOPMD(input_file):
         # open file for writing
         opmd_fname = input_file.replace(".h5", ".opmd.h5")
 
-        series = opmd.Series(opmd_fname, opmd.Access_Type.create)
+        series = opmd.Series(opmd_fname, opmd.Access.create)
 
         # Add metadata
         series.set_author("SIMEX")


### PR DESCRIPTION
Just minor updates in openPMD-api 0.12.0:
- replace a newly deprecated class with its new name (`Access`)
- https://openpmd-api.readthedocs.io/en/0.12.0-alpha/install/upgrade.html

Packaging:
- fix the proper PyPA package name in `requirements.txt`
- add a version constrain that can be updated anytime, but guarantees
  definite compatibility